### PR TITLE
alternative activation encoding

### DIFF
--- a/proto/net.proto
+++ b/proto/net.proto
@@ -233,10 +233,10 @@ message NetworkFormat {
   optional MovesLeftFormat moves_left = 6;
 
   enum ActivationFunction {
-    INHERIT = 0;
-    NONE = 1;
+    DEFAULT = 0;
+    MISH = 1;
     RELU = 2;
-    MISH = 3;
+    NONE = 3;
     TANH = 4;
     SIGMOID = 5;
     SELU = 6;
@@ -263,6 +263,13 @@ message NetworkFormat {
     FFN_ACTIVATION_RELU_2 = 8;
   }
   optional FfnActivation ffn_activation = 9;
+
+  enum AttentionPolicyActivation {
+    ATTENTION_POLICY_ACTIVATION_SELU = 0;
+    ATTENTION_POLICY_ACTIVATION_MISH = 1;
+    ATTENTION_POLICY_ACTIVATION_RELU = 3;
+  }
+  optional AttentionPolicyActivation attention_policy_activation = 10;
 }
 
 message Format {

--- a/proto/net.proto
+++ b/proto/net.proto
@@ -263,13 +263,6 @@ message NetworkFormat {
     FFN_ACTIVATION_RELU_2 = 8;
   }
   optional FfnActivation ffn_activation = 9;
-
-  enum AttentionPolicyActivation {
-    ATTENTION_POLICY_ACTIVATION_SELU = 0;
-    ATTENTION_POLICY_ACTIVATION_MISH = 1;
-    ATTENTION_POLICY_ACTIVATION_RELU = 3;
-  }
-  optional AttentionPolicyActivation attention_policy_activation = 10;
 }
 
 message Format {


### PR DESCRIPTION
This is my alternative activation encoding, trying to also add attention policy activation in a backwards compatible way: My rationalization is to make activation 0 be `DEFAULT` instead of `INHERIT` and define what the default is in each case, mostly `INHERIT` but where this is currently different use the backward compatible function (i.e. RELU or SELU). Everything non-zero should match the `ActivationFunction` list, so `MISH` is now 1 and the backend code only has to check for zero to do the locally correct thing, otherwise use the `ActivationFunction` number (and seeing zero at the lower level should throw an exception).